### PR TITLE
The {#foo} spec talks about false and empty lists, but example says true...

### DIFF
--- a/mustache.5.html
+++ b/mustache.5.html
@@ -176,7 +176,7 @@ list, the HTML between the pound and slash will not be displayed.</p>
 <p>Hash:</p>
 
 <pre><code>{
-  "person": true,
+  "person": false,
 }
 </code></pre>
 


### PR DESCRIPTION
....
