### PR TITLE
Updated Lua link to current repository

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -25,7 +25,7 @@ languages:
   :name: C++
 - :url: https://github.com/hoisie/mustache.go/
   :name: Go
-- :url: https://github.com/nrk/hige
+- :url: https://github.com/Olivine-Labs/lustache
   :name: Lua
 - :url: https://github.com/joshthecoder/mustang
   :name: ooc

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ i__p__ /  |  ##############  | | ####### |__l___xp____| ooooo |      |~~~~|
         <a href="https://github.com/samskivert/jmustache">Android</a>,
         <a href="https://github.com/mrtazz/plustache">C++</a>,
         <a href="https://github.com/hoisie/mustache.go/">Go</a>,
-        <a href="https://github.com/nrk/hige">Lua</a>,
+        <a href="https://github.com/Olivine-Labs/lustache">Lua</a>,
         <a href="https://github.com/joshthecoder/mustang">ooc</a>,
         <a href="https://github.com/hyakugei/mustache.as">ActionScript</a>,
         <a href="https://github.com/pmcelhaney/Mustache.cfc">ColdFusion</a>,


### PR DESCRIPTION
The currently linked Lua repository is incomplete and unmaintained; I've moved the link to an updated repository that supports current Mustache features.
