### PR TITLE
Bug report: Demo doesn't handle whitespace correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Want your implementation listed on this site?
 2. Send a [message](https://github.com/inbox/new/defunkt) to defunkt
 
 That's it!
+


### PR DESCRIPTION
**This is a bug report only, I don't have a fix for it.**

template:

```
FOO

    {{#section}}BAR{{/section}}
```

data:

```
section: [""]
```

Expected result (this also the _actual_ result from the main Ruby commandline mustache tool):

```
FOO

    BAR
```

Actual result on http://mustache.github.com/#demo:

```
FOO
BAR
```
