### PR TITLE
Add racket language to the list of implementations

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -61,6 +61,8 @@
   url:  https://github.com/TomahawX/Mustache.hx
 - name: Delphi
   url:  https://github.com/synopse/dmustache
+- name: Racket
+  url:  https://github.com/rcherrueau/rastache
 
 # TODO: include handlebars implementations?
 # - name: Java


### PR DESCRIPTION
Rastache is a Racket implementation of Mustache template compliant with Mustache specs v1.1+λ
