### PR TITLE
Fix HTTP/HTTPS and add Atom

### DIFF
--- a/_data/editors.yml
+++ b/_data/editors.yml
@@ -2,10 +2,12 @@
 # Please add new editors to the end!
 
 - name: TextMate
-  url:  http://gist.github.com/323624
+  url:  https://gist.github.com/323624
 - name: Vim
   url:  https://github.com/mustache/vim-mustache-handlebars
 - name: Emacs
-  url:  http://gist.github.com/323619
+  url:  https://gist.github.com/323619
 - name: Coda
-  url:  http://github.com/bobthecow/Mustache.mode
+  url:  https://github.com/bobthecow/Mustache.mode
+- name: Atom
+  url:  https://github.com/atom/language-mustache


### PR DESCRIPTION
I've just consolidated the HTTP and HTTPS links in this file, as :octocat: seems to prefer HTTPS. Also, atom supports Mustache out of the box, so I've added that too.
