### PR TITLE
Replace deprecated Haskell lib

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -48,7 +48,7 @@
 - name: D
   url:  https://github.com/repeatedly/mustache-d
 - name: Haskell
-  url:  https://github.com/lymar/hastache
+  url:  https://github.com/JustusAdam/mustache
 - name: XQuery
   url:  https://github.com/dscape/mustache.xq
 - name: ASP


### PR DESCRIPTION
As mentioned [on stackage](https://hackage.haskell.org/package/hastache), the [hastache](https://github.com/lymar/hastache) has been deprecated in favor [mustache](https://github.com/JustusAdam/mustache). It'd be nice to lead people straight to the new one.