### PR TITLE
Update clojure repo

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -41,8 +41,8 @@
   url:  https://github.com/pmcelhaney/Mustache.cfc
 - name: Scala
   url:  https://github.com/scalate/scalate
-- name: Clojure
-  url:  https://github.com/fhd/clostache
+- name: Clojure[Script]
+  url:  https://github.com/fotoetienne/cljstache
 - name: Fantom
   url:  https://github.com/vspy/mustache
 - name: CoffeeScript


### PR DESCRIPTION
The clojure implementation of mustache has been forked in order to provide compatibility with current versions of Clojure as well as to extend support to ClojureScript. This change references the new repository.