### PR TITLE
Adds the language C

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -87,6 +87,8 @@
   url: http://norbert.hartl.name/blog/2013/10/03/mustache-templates-for-smalltalk/
 - name: Tcl
   url: https://github.com/ianka/mustache.tcl
+- name: C
+  url: https://gitlab.com/jobol/mustach
 
 # TODO: include handlebars implementations?
 # - name: Java


### PR DESCRIPTION
Adds a link for a tiny C implementation.

This implementation is open source, licensed under APACHE 2.0, and doesn't requires any library.