### PR TITLE
Specify a character for escaped substitution

### DIFF
--- a/mustache.5.html
+++ b/mustache.5.html
@@ -168,6 +168,14 @@ supports raising an exception in this situation, for instance.</p>
 * &lt;b&gt;GitHub&lt;/b&gt;
 </code></pre>
 
+<p>When the name of the variable starts with a character that is normally interpreted within
+mustache templating use colon (:) as first character to escape it.
+Writing <code>{{NAME}}</code> is equivalent to writing <code>{{:NAME}}</code> and
+conversely and represent the variable substitution even when
+<code>NAME</code>, the variable name, begins with one of this special characters:
+<code>#^/{&amp;!&gt;:</code>.</p>
+
+
 <h3 id="Sections">Sections</h3>
 
 <p>Sections render blocks of text one or more times, depending on the


### PR DESCRIPTION
When the name of the variable starts with a character that is normally interpreted within
mustache templating (i.e. "#^/{&!>:") it should be possible to use an escape character.
This commit propose to use colon (:) as first character to escape the first character of
variable name in the variable substitution with escaping.
Writing {{:NAME}} is equivalent to writing {{NAME}} even when
NAME begins with a special character.

It is interesting to see that it specify an optional character for variable
substitution with escaping and not only an escaping character.
