### PR TITLE
Update languages.yml

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -22,7 +22,7 @@
 - name: Java
   url:  https://github.com/spullara/mustache.java
 - name: C#/.NET
-  url:  https://github.com/jdiamond/Nustache
+  url:  https://github.com/StubbleOrg/Stubble
 - name: Android
   url:  https://github.com/samskivert/jmustache
 - name: C++


### PR DESCRIPTION
Replaces Nustache with the newly released successor Stubble which is cross platform.

I'm the maintainer of Nustache and not likely to keep updating it after releasing Stubble so people should be directed towards Stubble instead.