### PR TITLE
update nim link

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -84,7 +84,7 @@
 - name: Common Lisp
   url: https://github.com/kanru/cl-mustache/
 - name: Nim
-  url: https://github.com/fenekku/moustachu
+  url: https://github.com/soasme/nim-mustache
 - name: Pharo
   url: https://github.com/noha/mustache
 - name: Tcl


### PR DESCRIPTION
The new link is a complete implementation that is stable and more maintained (according to the readme).